### PR TITLE
[spiceai-0.17.0] Fix data skipping for `>=` timestamp predicates #6

### DIFF
--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -843,23 +843,30 @@ pub trait DataSkippingPredicateEvaluator {
     ) -> Option<Self::Output> {
         let max = self.get_max_stat(col, &val.data_type())?;
 
-        // Delta Lake min/max stats are stored with millisecond precision (truncated, not rounded up) so we can't use direct comparison.
-        // For Ordering::Greater comparison we adjust timestamp values by subtracting 999 microseconds from the value to ensure
+        // Delta Lake min/max stats are stored with millisecond precision (truncated, not rounded up), so we can't use direct comparison.
+        // For max stats comparison, we adjust timestamp values by subtracting 999 microseconds from the value to ensure
         // that comparisons against max stats are correct. Any rows that pass this filter will be re-evaluated later for exact matches.
         // See:
-        // - https://github.com/delta-io/delta-kernel-rs/issues/1002
         // - https://github.com/delta-io/delta-kernel-rs/pull/1003
         if matches!(val, Scalar::Timestamp(_) | Scalar::TimestampNtz(_)) {
-            if !inverted && ord == Ordering::Greater {
-                let max_ts_adjusted = timestamp_subtract(val, 999);
-                tracing::debug!(
-                "Adjusted timestamp value for col {col} for max stat comparison from {val:?} to {max_ts_adjusted:?}"
-                );
-                return self.eval_partial_cmp(ord, max, &max_ts_adjusted, inverted);
+            match (ord, inverted) {
+                // col > val => stats.max.col > val
+                // NOT(col < val) => NOT(stats.max.col < val)
+                (Ordering::Greater, false) | (Ordering::Less, true) => {
+                    let max_ts_adjusted = timestamp_subtract(val, 999);
+                    tracing::debug!(
+                        "Adjusted timestamp value for col {col} for max stat comparison from {val:?} to {max_ts_adjusted:?}"
+                    );
+                    return self.eval_partial_cmp(ord, max, &max_ts_adjusted, inverted);
+                }
+                // // The following case is not currently used but included for completeness and to ensure correctness in the future if logic is changed to use it.
+                // !(max > val) or max < val
+                (Ordering::Greater, true) | (Ordering::Less, false) => {
+                    return self.eval_partial_cmp(ord, max, val, inverted);
+                }
+                // Equality comparison can't be applied as max stats is truncated to milliseconds, so actual microsecond value is unknown.
+                (Ordering::Equal, _) => return None,
             }
-
-            // Disabled by default: https://github.com/delta-io/delta-kernel-rs/issues/1002
-            return None;
         }
 
         self.eval_partial_cmp(ord, max, val, inverted)

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -365,7 +365,7 @@ fn test_timestamp_predicates_data_skip() {
         let skipping_pred = as_data_skipping_predicate(&pred);
         assert_eq!(
             skipping_pred.unwrap().to_string(),
-            "AND(NOT(Column(minValues.ts_col) > 1000000), null)"
+            "AND(NOT(Column(minValues.ts_col) > 1000000), NOT(Column(maxValues.ts_col) < 999001))"
         );
 
         let pred = Pred::ne(col.clone(), timestamp.clone());


### PR DESCRIPTION
## What changes are proposed in this pull request?

Backport the following improvement into `spiceai-0.17.0`
- https://github.com/spiceai/delta-kernel-rs/pull/6

Verified build + data skipping tests

```
running 6 tests
test scan::data_skipping::tests::test_eval_junction ... ok
test scan::data_skipping::tests::test_eval_is_null ... ok
test scan::data_skipping::tests::test_timestamp_predicates_data_skip ... ok
test scan::data_skipping::tests::test_eval_binary_comparisons ... ok
test scan::data_skipping::tests::test_sql_where ... ok
test scan::data_skipping::tests::test_eval_distinct ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 652 filtered out; finished in 0.00s
```