### PR TITLE
Port Spice patches to Delta Kernel 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,19 @@ repository = "https://github.com/delta-io/delta-kernel-rs"
 readme = "README.md"
 rust-version = "1.85"
 version = "0.17.0"
+
+[patch.crates-io]
+# Use spiceai arrow-rs fork with new_with_meta API
+arrow = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-array = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-buffer = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-cast = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-data = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-ipc = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-json = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-ord = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-row = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-schema = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-select = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+arrow-string = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }
+parquet = { git = "https://github.com/spiceai/arrow-rs.git", branch = "spiceai-57" }

--- a/kernel/src/engine/default/parquet.rs
+++ b/kernel/src/engine/default/parquet.rs
@@ -15,8 +15,9 @@ use crate::parquet::arrow::arrow_reader::{
 use crate::parquet::arrow::arrow_writer::ArrowWriter;
 use crate::parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use futures::StreamExt;
+use chrono::DateTime;
 use object_store::path::Path;
-use object_store::DynObjectStore;
+use object_store::{DynObjectStore, ObjectMeta};
 use uuid::Uuid;
 
 use super::file_stream::{FileOpenFuture, FileOpener, FileStream};
@@ -288,6 +289,22 @@ impl FileOpener for ParquetOpener {
         Ok(Box::pin(async move {
             let mut reader = {
                 use object_store::ObjectStoreScheme;
+
+                let Some(last_modified) = DateTime::from_timestamp_millis(file_meta.last_modified)
+                else {
+                    return Err(Error::generic(format!(
+                        "Unable to convert FileMeta last modified time: {}",
+                        file_meta.last_modified
+                    )));
+                };
+
+                let object_meta = ObjectMeta {
+                    location: Path::from_url_path(file_meta.location.path())?,
+                    last_modified,
+                    size: file_meta.size,
+                    e_tag: None,
+                    version: None,
+                };
                 // HACK: unfortunately, `ParquetObjectReader` under the hood does a suffix range
                 // request which isn't supported by Azure. For now we just detect if the URL is
                 // pointing to azure and if so, do a HEAD request so we can pass in file size to the
@@ -305,7 +322,7 @@ impl FileOpener for ParquetOpener {
                     let meta = store.head(&path).await?;
                     ParquetObjectReader::new(store, path).with_file_size(meta.size)
                 } else {
-                    ParquetObjectReader::new(store, path)
+                    ParquetObjectReader::new_with_meta(store, object_meta)
                 }
             };
 

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -843,20 +843,23 @@ pub trait DataSkippingPredicateEvaluator {
     ) -> Option<Self::Output> {
         let max = self.get_max_stat(col, &val.data_type())?;
 
-        // Delta Lake min/max stats are stored with millisecond precision (truncated, not rounded up),
-        // so we need to adjust timestamp values by subtracting 999 microseconds from the value to ensure
-        // that comparisons against max stats are correct. 
-        // Any rows that pass this filter will be re-evaluated later for exact matches.
+        // Delta Lake min/max stats are stored with millisecond precision (truncated, not rounded up) so we can't use direct comparison.
+        // For Ordering::Greater comparison we adjust timestamp values by subtracting 999 microseconds from the value to ensure
+        // that comparisons against max stats are correct. Any rows that pass this filter will be re-evaluated later for exact matches.
         // See:
         // - https://github.com/delta-io/delta-kernel-rs/issues/1002
         // - https://github.com/delta-io/delta-kernel-rs/pull/1003
+        if matches!(val, Scalar::Timestamp(_) | Scalar::TimestampNtz(_)) {
+            if !inverted && ord == Ordering::Greater {
+                let max_ts_adjusted = timestamp_subtract(val, 999);
+                tracing::debug!(
+                "Adjusted timestamp value for col {col} for max stat comparison from {val:?} to {max_ts_adjusted:?}"
+                );
+                return self.eval_partial_cmp(ord, max, &max_ts_adjusted, inverted);
+            }
 
-        if !inverted && ord == Ordering::Greater && matches!(val, Scalar::Timestamp(_) | Scalar::TimestampNtz(_)) {
-            let max_ts_adjusted = timestamp_subtract(val, 999);
-            tracing::debug!(
-               "Adjusted timestamp value for col {col} for max stat comparison from {val:?} to {max_ts_adjusted:?}"
-            );
-            return self.eval_partial_cmp(ord, max, &max_ts_adjusted, inverted);
+            // Disabled by default: https://github.com/delta-io/delta-kernel-rs/issues/1002
+            return None;
         }
 
         self.eval_partial_cmp(ord, max, val, inverted)
@@ -1004,16 +1007,11 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
     }
 }
 
-
 /// Adjust timestamp value by subtracting the given interval in microseconds.
 fn timestamp_subtract(val: &Scalar, interval_micros: i64) -> Scalar {
     match val {
-        Scalar::Timestamp(ts) => {
-            Scalar::Timestamp(*ts - interval_micros)
-        },
-        Scalar::TimestampNtz(ts) => {
-            Scalar::TimestampNtz(*ts - interval_micros)
-        },
+        Scalar::Timestamp(ts) => Scalar::Timestamp(*ts - interval_micros),
+        Scalar::TimestampNtz(ts) => Scalar::TimestampNtz(*ts - interval_micros),
         _ => val.clone(),
     }
 }

--- a/kernel/src/kernel_predicates/mod.rs
+++ b/kernel/src/kernel_predicates/mod.rs
@@ -842,6 +842,23 @@ pub trait DataSkippingPredicateEvaluator {
         inverted: bool,
     ) -> Option<Self::Output> {
         let max = self.get_max_stat(col, &val.data_type())?;
+
+        // Delta Lake min/max stats are stored with millisecond precision (truncated, not rounded up),
+        // so we need to adjust timestamp values by subtracting 999 microseconds from the value to ensure
+        // that comparisons against max stats are correct. 
+        // Any rows that pass this filter will be re-evaluated later for exact matches.
+        // See:
+        // - https://github.com/delta-io/delta-kernel-rs/issues/1002
+        // - https://github.com/delta-io/delta-kernel-rs/pull/1003
+
+        if !inverted && ord == Ordering::Greater && matches!(val, Scalar::Timestamp(_) | Scalar::TimestampNtz(_)) {
+            let max_ts_adjusted = timestamp_subtract(val, 999);
+            tracing::debug!(
+               "Adjusted timestamp value for col {col} for max stat comparison from {val:?} to {max_ts_adjusted:?}"
+            );
+            return self.eval_partial_cmp(ord, max, &max_ts_adjusted, inverted);
+        }
+
         self.eval_partial_cmp(ord, max, val, inverted)
     }
 
@@ -984,5 +1001,19 @@ impl<T: DataSkippingPredicateEvaluator + ?Sized> KernelPredicateEvaluator for T 
         inverted: bool,
     ) -> Option<Self::Output> {
         self.finish_eval_pred_junction(op, preds, inverted)
+    }
+}
+
+
+/// Adjust timestamp value by subtracting the given interval in microseconds.
+fn timestamp_subtract(val: &Scalar, interval_micros: i64) -> Scalar {
+    match val {
+        Scalar::Timestamp(ts) => {
+            Scalar::Timestamp(*ts - interval_micros)
+        },
+        Scalar::TimestampNtz(ts) => {
+            Scalar::TimestampNtz(*ts - interval_micros)
+        },
+        _ => val.clone(),
     }
 }

--- a/kernel/src/scan/data_skipping.rs
+++ b/kernel/src/scan/data_skipping.rs
@@ -218,14 +218,8 @@ impl DataSkippingPredicateEvaluator for DataSkippingPredicateCreator {
         Some(joined_column_expr!("minValues", col))
     }
 
-    /// Retrieves the maximum value of a column, if it exists and has the requested type.
-    // TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since
-    // they are truncated to milliseconds in add.stats.
-    fn get_max_stat(&self, col: &ColumnName, data_type: &DataType) -> Option<Expr> {
-        match data_type {
-            &DataType::TIMESTAMP | &DataType::TIMESTAMP_NTZ => None,
-            _ => Some(joined_column_expr!("maxValues", col)),
-        }
+    fn get_max_stat(&self, col: &ColumnName, _data_type: &DataType) -> Option<Expr> {
+        Some(joined_column_expr!("maxValues", col))
     }
 
     /// Retrieves the null count of a column, if it exists.

--- a/kernel/src/scan/data_skipping/tests.rs
+++ b/kernel/src/scan/data_skipping/tests.rs
@@ -340,39 +340,9 @@ fn test_sql_where() {
     do_test(ALL_NULL, pred, MISSING, None, None);
 }
 
-// TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since they
-// are truncated to milliseconds in add.stats.
-#[test]
-fn test_timestamp_skipping_disabled() {
-    let creator = DataSkippingPredicateCreator;
-    let col = &column_name!("timestamp_col");
 
-    assert!(
-        creator.get_min_stat(col, &DataType::TIMESTAMP).is_some(),
-        "get_min_stat should return Some: allow data skipping on timestamp minValues"
-    );
-    assert_eq!(
-        creator.get_max_stat(col, &DataType::TIMESTAMP),
-        None,
-        "get_max_stat should return None: no data skipping on timestamp maxValues"
-    );
-    assert!(
-        creator
-            .get_min_stat(col, &DataType::TIMESTAMP_NTZ)
-            .is_some(),
-        "get_min_stat should return Some: allow data skipping on timestamp_ntz minValues"
-    );
-    assert_eq!(
-        creator.get_max_stat(col, &DataType::TIMESTAMP_NTZ),
-        None,
-        "get_max_stat should return None: no data skipping on timestamp_ntz maxValues"
-    );
-}
-
-// TODO(#1002): we currently don't support file skipping on timestamp columns' max stat since they
-// are truncated to milliseconds in add.stats.
 #[test]
-fn test_timestamp_predicates_dont_data_skip() {
+fn test_timestamp_predicates_data_skip() {
     let col = &column_expr!("ts_col");
     for timestamp in [&Scalar::Timestamp(1000000), &Scalar::TimestampNtz(1000000)] {
         // LT will do minValues -> OK
@@ -383,12 +353,12 @@ fn test_timestamp_predicates_dont_data_skip() {
             "Column(minValues.ts_col) < 1000000"
         );
 
-        // GT will do maxValues -> BLOCKED
+        // GT will adjust predicate value for maxValues comparison
         let pred = Pred::gt(col.clone(), timestamp.clone());
         let skipping_pred = as_data_skipping_predicate(&pred);
-        assert!(
-            skipping_pred.is_none(),
-            "Expected no data skipping for timestamp predicate: {pred:#?}, got {skipping_pred:#?}"
+        assert_eq!(
+            skipping_pred.unwrap().to_string(),
+            "Column(maxValues.ts_col) > 999001"
         );
 
         let pred = Pred::eq(col.clone(), timestamp.clone());


### PR DESCRIPTION
Ports the previous Spice fork branch onto the Delta Kernel 0.18.2 feature branch.

Base: `spiceai-0.18.2`
Head: `spiceai-0.18.2-patches`

This follows the DataFusion upgrade guide branch shape: patch PRs target the version branch, not the repository default branch.